### PR TITLE
Raise a RuntimeError with a specific message when the user is not found

### DIFF
--- a/lib/togglehq/notify/user_settings.rb
+++ b/lib/togglehq/notify/user_settings.rb
@@ -59,6 +59,8 @@ module Togglehq
         if response.status == 200
           @groups = JSON.parse(response.body)
           return @groups
+        elsif response.status == 404
+          raise "user not found"
         else
           raise "Unexpected error getting app settings"
         end

--- a/spec/togglehq/notify/user_settings_spec.rb
+++ b/spec/togglehq/notify/user_settings_spec.rb
@@ -40,6 +40,15 @@ module Togglehq
           end
         end
 
+        context "response status 404" do
+          it "raises a RuntimeError with a message that the user was not found" do
+            expect(Togglehq::Request).to receive(:new).with("/settings", {"user" => {"identifier" => user.identifier}}).and_return(mock_request)
+            expect(mock_request).to receive(:get!).and_return(mock_response)
+            expect(mock_response).to receive(:status).twice.and_return(404)
+            expect {user_settings.groups}.to raise_error(RuntimeError, "user not found")
+          end
+        end
+
         context "unexpected status" do
           it "raises a RuntimeError" do
             expect(Togglehq::Request).to receive(:new).with("/settings", {"user" => {"identifier" => user.identifier}}).and_return(mock_request)


### PR DESCRIPTION
Ping @mikefogg 

As discussed, this will allow you to handle the case where the user doesn't exist.