### PR TITLE
Fix: Togglehq::User.find_by_identifier! not returning user

### DIFF
--- a/lib/togglehq/user.rb
+++ b/lib/togglehq/user.rb
@@ -25,6 +25,7 @@ module Togglehq
     def self.find_by_identifier!(identifier)
       user = self.find_by_identifier(identifier)
       raise "Could not find user with identifier #{identifier}" if user.nil?
+      return user
     end
 
     # Saves a new user

--- a/spec/togglehq/user_spec.rb
+++ b/spec/togglehq/user_spec.rb
@@ -59,6 +59,9 @@ module Togglehq
     context ".find_by_identifier!" do
       let(:mock_request) { double("request") }
       let(:mock_response) { double("response") }
+      let(:success_response) do
+        {"identifier" => "foo"}.to_json
+      end
 
       context "user not found" do
         it "raises a RuntimeError" do
@@ -66,6 +69,19 @@ module Togglehq
           expect(mock_request).to receive(:get!).and_return(mock_response)
           allow(mock_response).to receive(:status).and_return(404)
           expect {Togglehq::User.find_by_identifier!("foo")}.to raise_error(RuntimeError, "Could not find user with identifier foo")
+        end
+      end
+
+      context "response status 200" do
+        it "returns a Togglehq::User object" do
+          expect(Togglehq::Request).to receive(:new).with("/users/foo").and_return(mock_request)
+          expect(mock_request).to receive(:get!).and_return(mock_response)
+          expect(mock_response).to receive(:body).and_return(success_response)
+          allow(mock_response).to receive(:status).and_return(200)
+          user = Togglehq::User.find_by_identifier!("foo")
+          expect(user).not_to eq(nil)
+          expect(user).to be_a(Togglehq::User)
+          expect(user.identifier).to eq("foo")
         end
       end
     end


### PR DESCRIPTION
Ping @mikefogg 

Happened to notice this bug when using the gem:

```ruby
2.3.0 :037 >   user = Togglehq::User.find_by_identifier!("testuser")
 => nil 
2.3.0 :038 > user.inspect
 => "nil" 
```

The method was not returning the user after the check for not found, hence the nil. Fixed, and added a missing spec that would have caught this.